### PR TITLE
linux ubuntu

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -17,7 +17,7 @@
     "@radix-ui/react-scroll-area": "^1.2.9",
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
-    "@rollup/rollup-darwin-x64": "^4.45.0",
+    "@rollup/rollup-darwin-arm64": "^4.45.0",
     "@tailwindcss/postcss": "^4.1.11",
     "@tailwindcss/vite": "^4.1.11",
     "@tanstack/react-query": "^5.82.0",

--- a/client/package.json
+++ b/client/package.json
@@ -17,7 +17,7 @@
     "@radix-ui/react-scroll-area": "^1.2.9",
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
-    "@rollup/rollup-darwin-arm64": "^4.45.0",
+    "@rollup/rollup-linux-x64-gnu": "^4.45.0",
     "@tailwindcss/postcss": "^4.1.11",
     "@tailwindcss/vite": "^4.1.11",
     "@tanstack/react-query": "^5.82.0",

--- a/server-ts/package.json
+++ b/server-ts/package.json
@@ -35,7 +35,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@rollup/rollup-darwin-x64": "^4.45.0",
+    "@rollup/rollup-darwin-arm64": "^4.45.0",
     "@supabase/supabase-js": "^2.38.4",
     "bcrypt": "^5.1.1",
     "cors": "^2.8.5",

--- a/server-ts/package.json
+++ b/server-ts/package.json
@@ -35,7 +35,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@rollup/rollup-darwin-arm64": "^4.45.0",
+    "@rollup/rollup-linux-x64-gnu": "^4.45.0",
     "@supabase/supabase-js": "^2.38.4",
     "bcrypt": "^5.1.1",
     "cors": "^2.8.5",


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Switch Rollup binaries to the correct platform targets: client now uses @rollup/rollup-linux-x64-gnu for Ubuntu, and server uses @rollup/rollup-darwin-arm64 for Apple Silicon macOS.
Fixes npm install and build errors on those environments.

<!-- End of auto-generated description by cubic. -->

